### PR TITLE
Custom filenames

### DIFF
--- a/src/batch.ts
+++ b/src/batch.ts
@@ -149,6 +149,7 @@ function parse(args: string[]): IConfigLine
     .option('-f, --format <s>', 'The subtitle format. (Default: ass)')
     .option('-o, --output <s>', 'The output path.')
     .option('-s, --series <s>', 'The series override.')
+    .option('-n, --filename <s>', 'The name override.')
     .option('-t, --tag <s>', 'The subgroup. (Default: CrunchyRoll)')
     .parse(args);
 }

--- a/src/episode.ts
+++ b/src/episode.ts
@@ -205,7 +205,10 @@ function name(config: IConfig, page: IEpisodePage, series: string, extra: string
       .replace(/{EPISODE_NUMBER}/g, episode)
       .replace(/{SEASON_NUMBER}/g, volume)
       .replace(/{VOLUME_NUMBER}/g, volume)
+      .replace(/{SEASON_TITLE}/g, page.season)
+      .replace(/{VOLUME_TITLE}/g, page.season)
       .replace(/{SERIES_TITLE}/g, series)
+      .replace(/{EPISODE_TITLE}/g, page.title)
       .replace(/{TAG}/g, tag) + extra;
 }
 
@@ -248,6 +251,7 @@ function scrapePage(config: IConfig, address: string, done: (err: Error, page?: 
     const regexp = /\s*([^\n\r\t\f]+)\n?\s*[^0-9]*([0-9][\-0-9.]*)?,?\n?\s\s*[^0-9]*((PV )?[S0-9][P0-9.]*[a-fA-F]?)/;
     const look = $('#showmedia_about_media').text();
     const seasonTitle = $('span[itemprop="title"]').text();
+    let episodeTitle = $('#showmedia_about_name').text().replace(/[“”]/g, '');
     const data = regexp.exec(look);
 
     if (!swf || !data)
@@ -258,6 +262,8 @@ function scrapePage(config: IConfig, address: string, done: (err: Error, page?: 
         episode: '0',
         id: epId,
         series: seasonTitle,
+        season: seasonTitle,
+        title: episodeTitle,
         swf: swf[1],
         volume: '0',
       });
@@ -268,6 +274,8 @@ function scrapePage(config: IConfig, address: string, done: (err: Error, page?: 
         episode: data[3],
         id: epId,
         series: data[1],
+        season: seasonTitle,
+        title: episodeTitle,
         swf: swf[1],
         volume: data[2] || '1',
       });

--- a/src/episode.ts
+++ b/src/episode.ts
@@ -196,7 +196,17 @@ function name(config: IConfig, page: IEpisodePage, series: string, extra: string
   const volume = (volumeNum < 10 ? '0' : '') + page.volume;
   const tag = config.tag || 'CrunchyRoll';
 
-  return series + ' - s' + volume + 'e' + episode + ' - [' + tag + ']' + extra;
+  if (!config.filename) {
+    return page.series + ' - s' + volume + 'e' + episode + ' - [' + tag + ']' + extra;
+  }
+
+  return config.filename
+      .replace(/{EPISODE_ID}/g, page.id.toString())
+      .replace(/{EPISODE_NUMBER}/g, episode)
+      .replace(/{SEASON_NUMBER}/g, volume)
+      .replace(/{VOLUME_NUMBER}/g, volume)
+      .replace(/{SERIES_TITLE}/g, series)
+      .replace(/{TAG}/g, tag) + extra;
 }
 
 /**

--- a/src/interface/IConfig.d.ts
+++ b/src/interface/IConfig.d.ts
@@ -12,5 +12,6 @@ interface IConfig {
   format?: string;
   output?: string;
   series?: string;
+  filename?: string;
   tag?: string;
 }

--- a/src/interface/IEpisodePage.d.ts
+++ b/src/interface/IEpisodePage.d.ts
@@ -3,5 +3,7 @@ interface IEpisodePage {
   episode: string;
   series: string;
   volume: string;
+  season: string;
+  title: string;
   swf: string;
 }


### PR DESCRIPTION
- Added `season` and `title` to `IEpisode` and the `scrapePage` function

- Added a filename override flag. Matching "variables" in the filename string will be replace with the value scraped from the episode page.

For example,
```
s{VOLUME_NUMBER}e{EPISODE_NUMBER} - {EPISODE_TITLE}
```
may become
```
s01e01 - Chapter 1 Rei Kiriyama _ Chapter 2 The Town Along the River.mkv
```