### PR TITLE
Saving credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,21 @@ The [command-line interface](http://en.wikipedia.org/wiki/Command-line_interface
 
     Options:
 
-      -h, --help         output usage information
-      -V, --version      output the version number
-      -p, --pass <s>     The password.
-      -u, --user <s>     The e-mail address or username.
-      -c, --cache        Disables the cache.
-      -m, --merge        Disables merging subtitles and videos.
-      -e, --episode <i>  The episode filter.
-      -v, --volume <i>   The volume filter.
-      -f, --format <s>   The subtitle format. (Default: ass)
-      -o, --output <s>   The output path.
-      -s, --series <s>   The series override.
-      -t, --tag <s>      The subgroup. (Default: CrunchyRoll)
+      -h, --help          output usage information
+      -V, --version       output the version number
+      -p, --pass <s>      The password.
+      -u, --user <s>      The e-mail address or username.
+      --save-credentials  Saves your account credentials.
+      --user-id           The user id from an existing session (browser cookie).
+      --user-key          The user key from an existing session (browser cookie).
+      -c, --cache         Disables the cache.
+      -m, --merge         Disables merging subtitles and videos.
+      -e, --episode <i>   The episode filter.
+      -v, --volume <i>    The volume filter.
+      -f, --format <s>    The subtitle format. (Default: ass)
+      -o, --output <s>    The output path.
+      -s, --series <s>    The series override.
+      -t, --tag <s>       The subgroup. (Default: CrunchyRoll)
 
 #### Batch-mode
 
@@ -94,6 +97,9 @@ Download *Fairy Tail* to `C:\Anime`:
 
 * `-p or --pass <s>` sets the password.
 * `-u or --user <s>` sets the e-mail address or username.
+* `--save-credentials` saves your account credentials.
+* `--user-id` sets the user id cookie.
+* `--user-key` sets the user key cookie.
 
  _Please remember that login has to be done for each call of Crunchy, as none of the credentials are stored_
 

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -139,6 +139,9 @@ function parse(args: string[]): IConfigLine
     // Authentication
     .option('-p, --pass <s>', 'The password.')
     .option('-u, --user <s>', 'The e-mail address or username.')
+    .option('--save-credentials', 'Saves your account credentials.')
+    .option('--user-id <s>', 'The user id from an existing session (browser cookie).')
+    .option('--user-key <s>', 'The user key from an existing session (browser cookie).')
     // Disables
     .option('-c, --cache', 'Disables the cache.')
     .option('-m, --merge', 'Disables merging subtitles and videos.')

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,66 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const configPath = path.resolve(os.homedir(), '.crunchyrc');
+
+let configCache: any;
+
+export function getConfig(done: (err: Error, config?: any) => void): void
+{
+  const callback = (err?: Error, config?: any) => {
+    if (!configCache)
+    {
+      configCache = config || {};
+    }
+
+    // return cloned config object so changes won't affect the cached config
+    done(err, JSON.parse(JSON.stringify(configCache)));
+  };
+
+  if (configCache)
+  {
+    return callback();
+  }
+
+  fs.access(configPath, (err) =>
+  {
+    if (err)
+    {
+      return callback(err);
+    }
+
+    fs.readFile(configPath, (err, data) =>
+    {
+      if (err)
+      {
+        return callback(err);
+      }
+
+      try
+      {
+        callback(null, JSON.parse(data.toString('utf8')) || {});
+      }
+      catch (err)
+      {
+        configCache = {};
+        callback(new Error('Failed to load config: ' + err));
+      }
+    });
+  });
+}
+
+export function saveConfig(config: any, done: (err: any) => void): void
+{
+  fs.writeFile(configPath, JSON.stringify(config, null, 2), (err) =>
+  {
+    if (err)
+    {
+      return done(err);
+    }
+
+    configCache = JSON.parse(JSON.stringify(config));
+
+    done(null);
+  });
+}

--- a/src/interface/IConfig.d.ts
+++ b/src/interface/IConfig.d.ts
@@ -2,6 +2,9 @@ interface IConfig {
   // Authentication
   pass?: string;
   user?: string;
+  saveCredentials?: boolean;
+  userId?: string;
+  userKey?: string;
   // Disables
   cache?: boolean;
   merge?: boolean;


### PR DESCRIPTION
- Added the ability to save credentials with `--save-credentials`

Reads the `c_userid` and `c_userkey` cookie values of a successfully authenticated session and saves them to `$HOME/.crunchyrc`
**OR**
Uses user provided `c_userid` and `c_userkey` values using `--user-id` and `--user-key`.

The `--user-id` and `--user-key` take priority over saved credentials.

The `--user` and `--pass` values take priority over user provided `c_userid` and `c_userkey` values.

When `--save-credentials` is passed with `--user-id` and `--user-key`, the previously saved credentials are overwritten by the credentials from new session.