### PR TITLE
Filtering out Pipe Symbol in file names

### DIFF
--- a/src/episode.ts
+++ b/src/episode.ts
@@ -66,7 +66,7 @@ function fileExist(path: string)
 
 function sanitiseFileName(str: string)
 {
-  return str.replace(/[\/':\?\*"<>\\\.]/g, '_');
+  return str.replace(/[\/':\?\*"<>\\\.\|]/g, '_');
 }
 
 /**


### PR DESCRIPTION
Updated sanitiseFileName to include the pipe symbol as this character is not allowed on windows.

The error thast it currently throws is: {"errno":-4058,"code":"ENOENT","syscall":"open","path":"K:\\MediaDwn\\Is It Wrong to Try to Pick Up Girls in a Dungeon_\\Is It Wrong to Try to Pick Up Girls in a Dungeon_ - s01e01 - Bell Cranel | Adventurer - [CrunchyRoll].ass"



### Checklist
[x] I've run `npm run compile` and it produce no error
[x] I've run `npm run test` and it produce no error
[x] I've not pushing more than one feature in that pull request
[x] My branch is updated with the latest from main when I make that pull request
[x] I've tested as much as I can my changes